### PR TITLE
Add safeinputs.phac

### DIFF
--- a/dns-records/entreessecurisees.aspc.alpha.canada.ca.yaml
+++ b/dns-records/entreessecurisees.aspc.alpha.canada.ca.yaml
@@ -1,0 +1,16 @@
+apiVersion: dns.cnrm.cloud.google.com/v1beta1
+kind: DNSRecordSet
+metadata:
+  name: entreessecurisees-aspc-alpha-canada-ca-ns
+  namespace: alpha-dns
+spec:
+  name: "entreessecurisees.aspc.alpha.canada.ca."
+  type: "NS"
+  ttl: 300
+  managedZoneRef:
+    external: aspc-alpha-canada-ca
+  rrdatas:
+    - ns-cloud-b1.googledomains.com.
+    - ns-cloud-b2.googledomains.com.
+    - ns-cloud-b3.googledomains.com.
+    - ns-cloud-b4.googledomains.com.

--- a/dns-records/safeinputs.phac.alpha.canada.ca.yaml
+++ b/dns-records/safeinputs.phac.alpha.canada.ca.yaml
@@ -1,0 +1,16 @@
+apiVersion: dns.cnrm.cloud.google.com/v1beta1
+kind: DNSRecordSet
+metadata:
+  name: safeinputs-phac-alpha-canada-ca-ns
+  namespace: alpha-dns
+spec:
+  name: "safeinputs.phac.alpha.canada.ca."
+  type: "NS"
+  ttl: 300
+  managedZoneRef:
+    external: phac-alpha-canada-ca
+  rrdatas:
+    - ns-cloud-a1.googledomains.com.
+    - ns-cloud-a2.googledomains.com.
+    - ns-cloud-a3.googledomains.com.
+    - ns-cloud-a4.googledomains.com.


### PR DESCRIPTION
Add delegation record for safeinputs.phac.alpha.canada.ca and entreessecurisees.aspc.alpha.canada.

The idea here is to have separate domains for French and English versions.

If this is merged, please disregard https://github.com/PHACDataHub/dns/pull/11.