### PR TITLE
Add safeinputs.phac-aspc

### DIFF
--- a/dns-records/safeinputs.phac-aspc.alpha.canada.ca.yaml
+++ b/dns-records/safeinputs.phac-aspc.alpha.canada.ca.yaml
@@ -1,0 +1,16 @@
+apiVersion: dns.cnrm.cloud.google.com/v1beta1
+kind: DNSRecordSet
+metadata:
+  name: safeinputs-phac-aspc-alpha-canada-ca-ns
+  namespace: alpha-dns
+spec:
+  name: "safeinputs.phac-aspc.alpha.canada.ca."
+  type: "NS"
+  ttl: 300
+  managedZoneRef:
+    external: phac-aspc-alpha-canada-ca
+  rrdatas:
+    - "ns-cloud-b1.googledomains.com."
+    - "ns-cloud-b2.googledomains.com."
+    - "ns-cloud-b3.googledomains.com."
+    - "ns-cloud-b4.googledomains.com."


### PR DESCRIPTION
Add delegation record for safeinputs.phac-aspc.alpha.canada.ca

The idea here is to have one domain for French and English versions.

If this is merged, please disregard https://github.com/PHACDataHub/dns/pull/10.