### PR TITLE
Add GitHub repo name to template

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ metadata:
   name: <zone-name>
   namespace: alpha-dns
   labels:
-    codeRepo: <GitHub-repository>
+    ownerName: John Doe
+    ownerContact: John.Doe@google.com 
 spec:
   name: "<DNS-name>"
   type: "NS"

--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ metadata:
   name: <zone-name>
   namespace: alpha-dns
   labels:
-    ownerName: John Doe
-    ownerContact: John.Doe@google.com
+    ownerName: <Your Name>
+    ownerContact: <Your.Email@example.com>
     # If there isn't an associated GitHub repository, please comment out the next line 
     gitHubRepo: <GitHub-repository>
 spec:

--- a/README.md
+++ b/README.md
@@ -30,7 +30,9 @@ metadata:
   namespace: alpha-dns
   labels:
     ownerName: John Doe
-    ownerContact: John.Doe@google.com 
+    ownerContact: John.Doe@google.com
+    # If there isn't an associated GitHub repository, please comment out the next line 
+    gitHubRepo: <GitHub-repository>
 spec:
   name: "<DNS-name>"
   type: "NS"

--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ kind: DNSRecordSet
 metadata:
   name: <zone-name>
   namespace: alpha-dns
+  labels:
+    codeRepo: <GitHub-repository>
 spec:
   name: "<DNS-name>"
   type: "NS"


### PR DESCRIPTION
Thinking ahead to the PHAC Observatory, it would be amazing to have these domains grouped by project (product) and easily linked back to the code base to be able to scan and report on minimum standards.  Adding a label for the GitHub repo in the metadata can do this. Happy to change the label name. 

Possible concerns:
- This repo is public, and I'm anticipating that the majority of these projects will be private - is there any risk of outwardly naming private repos (ie. projects)? (I'm thinking of historically controversial projects like mobility data.)
- I know it's the goal to have everyone deploy their code through GitHub, but I anticipate there'll be a number of projects that go straight for the GCP console (maybe some Shiny apps)  - we may need to indicate that if there's no repo, to use "no-repo" to handle those differently - or would it be better to just remove that label tag for those cases? 