### PR TITLE
Minor HoPiC record patch, name servers have changed

### DIFF
--- a/dns-records/hopic-sdpac.phac-aspc.alpha.canada.ca.yaml
+++ b/dns-records/hopic-sdpac.phac-aspc.alpha.canada.ca.yaml
@@ -10,7 +10,7 @@ spec:
   managedZoneRef:
     external: "phac-aspc-alpha-canada-ca"
   rrdatas:
-    - "ns-cloud-b1.googledomains.com."
-    - "ns-cloud-b2.googledomains.com."
-    - "ns-cloud-b3.googledomains.com."
-    - "ns-cloud-b4.googledomains.com."
+    - "ns-cloud-e1.googledomains.com."
+    - "ns-cloud-e2.googledomains.com."
+    - "ns-cloud-e3.googledomains.com."
+    - "ns-cloud-e4.googledomains.com."


### PR DESCRIPTION
Wanted to rename the managed zone in the CPHO project, had to create a new resource to do so which ended up on a different set of name servers.