### PR TITLE
Another HoPiC name server rotation

### DIFF
--- a/dns-records/hopic-sdpac.phac-aspc.alpha.canada.ca.yaml
+++ b/dns-records/hopic-sdpac.phac-aspc.alpha.canada.ca.yaml
@@ -10,7 +10,7 @@ spec:
   managedZoneRef:
     external: "phac-aspc-alpha-canada-ca"
   rrdatas:
-    - "ns-cloud-a1.googledomains.com."
-    - "ns-cloud-a2.googledomains.com."
-    - "ns-cloud-a3.googledomains.com."
-    - "ns-cloud-a4.googledomains.com."
+    - "ns-cloud-d1.googledomains.com."
+    - "ns-cloud-d2.googledomains.com."
+    - "ns-cloud-d3.googledomains.com."
+    - "ns-cloud-d4.googledomains.com."


### PR DESCRIPTION
I tore down the HoPiC networking stack in the process of experimenting, and I kind of hoped I could just roll the dice on managed zones till it gave me back one with the "a" series name servers, haha. Seems resistant to it! Possible there's a security mechanism that tries to prevent an identical managed zone being swapped in under one that's referenced by a forwarding rule, as the previous version with the "a" name servers would still be?

Either way, have to bug you for yet another merge to swap these records, sorry! Might keep happening, we've got some more networking experimentation to do on CPHO. I'll try to avoid touching the managed zone though.