### PR TITLE
Phac gpt delegation

### DIFF
--- a/dns-records/phacgpt.phac.alpha.canada.ca.yaml
+++ b/dns-records/phacgpt.phac.alpha.canada.ca.yaml
@@ -1,0 +1,16 @@
+apiVersion: dns.cnrm.cloud.google.com/v1beta1
+kind: DNSRecordSet
+metadata:
+  name: phacgpt-phac-alpha-canada-ca-ns
+  namespace: alpha-dns
+spec:
+  name: "phacgpt.phac.alpha.canada.ca."
+  type: "NS"
+  ttl: 300
+  managedZoneRef:
+    external: phac-alpha-canada-ca
+  rrdatas:
+    - "ns-cloud-c1.googledomains.com."
+    - "ns-cloud-c2.googledomains.com."
+    - "ns-cloud-c3.googledomains.com."
+    - "ns-cloud-c4.googledomains.com."


### PR DESCRIPTION
Name delegation for phacgpt.phac.alpha.canada.ca . @juleskuehn  when you have a second take a look at the change, this will link your subdomain