### PR TITLE
Removed metadata labels for github repo and email

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,10 +29,16 @@ metadata:
   name: <zone-name>
   namespace: alpha-dns
   annotations:
-    ownerName: <Your Name>
-    ownerContact: <Your.Email@example.com>
-    # If there isn't an associated GitHub repository, please comment out the next line 
-    gitHubRepo: <GitHub-repository>
+    projectName: <your-project-name>
+    projectOwnerDivisionAcronym: <eg-DSCO-or-DS>
+  # The following items are optional - please comment out or remove lines that are not applicable 
+    gitHubRepository: <https://github.com/PHACDataHub/<repository-name>>
+    nonGitHubCodeRepository: <eg-azure-devops-repo>
+  # Include one line for each service, e.g. API, UI...
+    serviceURLs:
+      - <service-url>
+    containerRegistries:
+      - <eg-GCP-artifact-registry-or-docker-hub>
 spec:
   name: "<DNS-name>"
   type: "NS"

--- a/README.md
+++ b/README.md
@@ -28,8 +28,11 @@ kind: DNSRecordSet
 metadata:
   name: <zone-name>
   namespace: alpha-dns
-  labels:
-    ownerName: Your_Name
+  annotations:
+    ownerName: <Your Name>
+    ownerContact: <Your.Email@example.com>
+    # If there isn't an associated GitHub repository, please comment out the next line 
+    gitHubRepo: <GitHub-repository>
 spec:
   name: "<DNS-name>"
   type: "NS"

--- a/README.md
+++ b/README.md
@@ -30,9 +30,6 @@ metadata:
   namespace: alpha-dns
   labels:
     ownerName: <Your Name>
-    ownerContact: <Your.Email@example.com>
-    # If there isn't an associated GitHub repository, please comment out the next line 
-    gitHubRepo: <GitHub-repository>
 spec:
   name: "<DNS-name>"
   type: "NS"

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ metadata:
   name: <zone-name>
   namespace: alpha-dns
   labels:
-    ownerName: <Your Name>
+    ownerName: Your_Name
 spec:
   name: "<DNS-name>"
   type: "NS"


### PR DESCRIPTION
@KingBain discovered '@' and '/' are not valid characters for labels - we'll need to find an alternative solution later.  Kept name in as it *shouldn't cause any issues. 