### PR TITLE
Added metadata annotations for github repo and project name to dns records

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,16 +33,15 @@ metadata:
   name: <zone-name>
   namespace: alpha-dns
   annotations:
-    projectName: <your-project-name>
-    projectOwnerDivisionAcronym: <eg-DSCO-or-DS>
+    projectName: "<your-project-name>"
   # The following items are optional - please comment out or remove lines that are not applicable 
-    gitHubRepository: <https://github.com/PHACDataHub/<repository-name>>
+    gitHubRepository: <repository-name>
     nonGitHubCodeRepository: <eg-azure-devops-repo>
   # Include one line for each service, e.g. API, UI...
     serviceURLs:
       - <service-url>
     containerRegistries:
-      - <eg-GCP-artifact-registry-or-docker-hub>
+      - <container-registry>
 spec:
   name: "<DNS-name>"
   type: "NS"
@@ -59,6 +58,10 @@ spec:
 In the above template, fill out the values for placeholders(`<>`):
 
 - `<zone-name>`: Name of the resource, could be same as the Zone name that you've created.
+- `<project-name>`: Project name - spaces allowed (e.g. "PHAC Alpha DNS")
+- `<gitHubRepository>`: (e.g. "dns")
+- `<service-url>`: *Optional.* Add one for each service url, i.e. API, UI
+- `<container-registry>`: *Optional.* Add one for each container registry, e.g, GCP Artifact Registry or Docker Hub.
 - `<DNS-name>`: The DNS name from the previously created resource in your project. Don't forget the `.` at the end.
 - `<your-desired-value>`: Value to set for ttl (Time to Live). A good default for this is 300 but feel free to modify it. Units are in seconds.
 - `<zone-reference-name>`: This should be one of the three sub-domains we have. That is, one of `phac-aspc-alpha-canada-ca`, `phac-alpha-canada-ca` or `aspc-alpha-canada-ca`.

--- a/dns-records/cd-dc.phac-aspc.alpha.canada.ca.yaml
+++ b/dns-records/cd-dc.phac-aspc.alpha.canada.ca.yaml
@@ -3,6 +3,9 @@ kind: DNSRecordSet
 metadata:
   name: cd-dc-phac-aspc-alpha-canada-ca-ns
   namespace: alpha-dns
+  annotations:
+    projectName: "Data Catalog"
+    gitHubRepository: "data-catalog"
 spec:
   name: "cd-dc.phac-aspc.alpha.canada.ca."
   type: "NS"

--- a/dns-records/dc-cd.phac-aspc.alpha.canada.ca.yaml
+++ b/dns-records/dc-cd.phac-aspc.alpha.canada.ca.yaml
@@ -3,6 +3,9 @@ kind: DNSRecordSet
 metadata:
   name: dc-cd-phac-aspc-alpha-canada-ca-ns
   namespace: alpha-dns
+  annotations:
+    projectName: "Data Catalog"
+    gitHubRepository: "data-catalog"
 spec:
   name: "dc-cd.phac-aspc.alpha.canada.ca."
   type: "NS"

--- a/dns-records/dl.phac.alpha.canada.ca.yaml
+++ b/dns-records/dl.phac.alpha.canada.ca.yaml
@@ -3,6 +3,9 @@ kind: DNSRecordSet
 metadata:
   name: dl-phac-alpha-canada-ca-ns
   namespace: alpha-dns
+  annotations:
+    projectName: "Epicenter"
+    gitHubRepository: "phac-epi-garden"
 spec:
   name: "dl.phac.alpha.canada.ca."
   type: "NS"

--- a/dns-records/entreessecurisees.aspc.alpha.canada.ca.yaml
+++ b/dns-records/entreessecurisees.aspc.alpha.canada.ca.yaml
@@ -3,6 +3,9 @@ kind: DNSRecordSet
 metadata:
   name: entreessecurisees-aspc-alpha-canada-ca-ns
   namespace: alpha-dns
+  annotations:
+    projectName: "Safe Inputs"
+    gitHubRepository: "safe-inputs"
 spec:
   name: "entreessecurisees.aspc.alpha.canada.ca."
   type: "NS"

--- a/dns-records/hellodjango.phac-aspc.alpha.canada.ca.yaml.old
+++ b/dns-records/hellodjango.phac-aspc.alpha.canada.ca.yaml.old
@@ -5,8 +5,7 @@ metadata:
   namespace: alpha-dns
   annotations:
     projectName: "Hello Django"
-    projectOwnerDivisionAcronym: "DSCO"
-    gitHubRepository: "https://github.com/PHACDataHub/cloudrun-deployment-example"
+    gitHubRepository: "cloudrun-deployment-example"
     serviceURLs: "https://hello-world-from-cloud-build-trigger-vlfae7w5dq-nn.a.run.app"
     containerRegistries:
       - "northamerica-northeast1-docker.pkg.dev/phx-01h1yptgmche7jcy01wzzpw2rf/hello-world-app"

--- a/dns-records/hopic-sdpac.phac-aspc.alpha.canada.ca.yaml
+++ b/dns-records/hopic-sdpac.phac-aspc.alpha.canada.ca.yaml
@@ -3,6 +3,9 @@ kind: DNSRecordSet
 metadata:
   name: "hopic-sdpac-phac-aspc-alpha-canada-ca-ns"
   namespace: "alpha-dns"
+  annotations:
+    projectName: "HoPiC"
+    gitHubRepository: "cpho-phase2"
 spec:
   name: "hopic-sdpac.phac-aspc.alpha.canada.ca."
   type: "NS"

--- a/dns-records/jitaccess.ops.phac.alpha.canada.ca.yaml
+++ b/dns-records/jitaccess.ops.phac.alpha.canada.ca.yaml
@@ -3,6 +3,9 @@ kind: DNSRecordSet
 metadata:
   name: jitaccess-ops-phac-alpha-canada-ca-ns
   namespace: alpha-dns
+  annotations:
+    projectName: "JIT Access"
+    gitHubRepository: "JIT-IaC"
 spec:
   name: "jitaccess.ops.phac.alpha.canada.ca."
   type: "NS"

--- a/dns-records/safeinputs.phac-aspc.alpha.canada.ca.yaml
+++ b/dns-records/safeinputs.phac-aspc.alpha.canada.ca.yaml
@@ -3,6 +3,9 @@ kind: DNSRecordSet
 metadata:
   name: safeinputs-phac-aspc-alpha-canada-ca-ns
   namespace: alpha-dns
+  annotations:
+    projectName: "Safe Inputs"
+    gitHubRepository: "safe-inputs"
 spec:
   name: "safeinputs.phac-aspc.alpha.canada.ca."
   type: "NS"

--- a/dns-records/safeinputs.phac.alpha.canada.ca.yaml
+++ b/dns-records/safeinputs.phac.alpha.canada.ca.yaml
@@ -3,6 +3,9 @@ kind: DNSRecordSet
 metadata:
   name: safeinputs-phac-alpha-canada-ca-ns
   namespace: alpha-dns
+  annotations:
+    projectName: "Safe Inputs"
+    gitHubRepository: "safe-inputs"
 spec:
   name: "safeinputs.phac.alpha.canada.ca."
   type: "NS"


### PR DESCRIPTION
This is so we can use this information for the Observatory. The instructions part of the template was also updated, as the repo wasn't being filled in by new records. (and removed owner, as I'm not sure there is one in all contexts). 

Instead of updating all of the dns-record metadata, I'm just adding the 2 fields we're working with at the moment. There are 2-3 records not yet updated, and will reach out to those projects for correct names/ repos once this is tested out.  

Happy for feedback/ change suggestions! (Like is project the right term here?)

Update - talked to Keith - do not approve yet - lists in annotations will break things! 